### PR TITLE
Skip ads that have no skip button

### DIFF
--- a/youtube.js
+++ b/youtube.js
@@ -2,4 +2,12 @@ setInterval(() => {
   for (const button of document.getElementsByClassName("ytp-ad-skip-button")) {
     button.click(); // "Skip Ad" or "Skip Ads" buttons
   }
+
+  let progressBar = document.getElementsByClassName('ytp-play-progress')[0];
+  if (getComputedStyle(progressBar)['background-color'] === 'rgb(255, 204, 0)') {
+    let video = document.getElementsByClassName('html5-main-video')[0];
+    if (!video.paused) {
+      video.currentTime = video.duration;
+    }
+  }
 }, 300);


### PR DESCRIPTION
Some short ads doesn't have skip button (ads of few seconds, maybe up to 20 seconds).
This commit adds a way to also skip those ads (this solution could also replace the for and skip button click, theoretically).

Based on https://stackoverflow.com/a/48071848